### PR TITLE
fix: jdk man install java command

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ sdk list java
 and install a specific version:
 
 ```
-sdk install 17.0.8.1-tem
+sdk install java 21.0.3-tem
 ```
 
 Validate by checking the version:


### PR DESCRIPTION
Java needs to be specified before the version identifier. Also bumped to the latest LTS version.

Also I wonder what this part is for, it might be removed, or the headlines should be adjusted:
```
### Which version of Java do I currently have installed?
```
which java
`which java` --version
```
On Linux, you might also try
```
sudo update-java-alternatives
```

Indeed `java --version` is enough, and update-java-alternatives is not related to `Which version of Java do I currently have installed?` ?