### PR TITLE
Document Corretto 8 and 11 support for macOS/AArch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ macOS _x64_ builds run stable with Rosetta 2, but there is a significant perform
 People that develop on an _Apple Silicon_ Mac (like me) should install a native macOS _AArch64_ (aka _ARM 64_) build of the JDK.
 
 Most distributions have _macOS/AArch64_ builds for Java 17+, only.
-[BellSoft Liberica](https://bell-sw.com/announcements/2021/03/12/Liberica-on-Apple-Silicon/) and [Azul Zulu](https://www.azul.com/newsroom/azul-announces-support-of-java-builds-of-openjdk-for-apple-silicon/) also provide free _macOS/AArch64_ builds for Java 8 and Java 11.
+[BellSoft Liberica](https://bell-sw.com/announcements/2021/03/12/Liberica-on-Apple-Silicon/), Amazon Corretto, and [Azul Zulu](https://www.azul.com/newsroom/azul-announces-support-of-java-builds-of-openjdk-for-apple-silicon/) also provide free _macOS/AArch64_ builds for Java 8 and Java 11.
 
 
 ## FAQs


### PR DESCRIPTION
Fixes #40.

There is no news post about this, only Github issues. So I didn't add a link like Liberica and Zulu have. 